### PR TITLE
Feat/context data

### DIFF
--- a/src/zinc.zig
+++ b/src/zinc.zig
@@ -1,4 +1,5 @@
 pub const Context = @import("zinc/context.zig");
+pub const ContextData = @import("zinc/context_data.zig");
 pub const Config = @import("zinc/config.zig");
 pub const Catchers = @import("zinc/catchers.zig");
 pub const Engine = @import("zinc/engine.zig");
@@ -12,6 +13,7 @@ pub const HandlerFn = @import("zinc/handler.zig").HandlerFn;
 pub const Middleware = @import("zinc/middleware.zig");
 pub const RouterGroup = @import("zinc/routergroup.zig");
 pub const RouteTree = @import("zinc/routetree.zig").RouteTree;
+
 //
 // Create a new engine with the given config.
 pub fn init(conf: Config.Engine) anyerror!*Engine {

--- a/src/zinc.zig
+++ b/src/zinc.zig
@@ -1,5 +1,4 @@
 pub const Context = @import("zinc/context.zig");
-pub const ContextData = @import("zinc/context_data.zig");
 pub const Config = @import("zinc/config.zig");
 pub const Catchers = @import("zinc/catchers.zig");
 pub const Engine = @import("zinc/engine.zig");

--- a/src/zinc/config.zig
+++ b/src/zinc/config.zig
@@ -26,6 +26,12 @@ pub const Engine = struct {
 
     /// The number of threads to use. Maximum is 255.
     num_threads: u8 = 8,
+    /// Data of any arbitrary type that will be passed down to each Context
+    data: *anyopaque = undefined,
+
+    pub fn appData(self: *Engine, data: anytype) void {
+        self.data = data;
+    }
 };
 
 pub const Context = struct {

--- a/src/zinc/context.zig
+++ b/src/zinc/context.zig
@@ -33,6 +33,8 @@ handlers: std.ArrayList(handlerFn) = undefined,
 
 index: u8 = 0, // Adjust the type based on your specific needs
 
+data: *anyopaque,
+
 pub fn destroy(self: *Self) void {
     self.params.deinit();
     if (self.query_map != null) {
@@ -63,6 +65,7 @@ pub fn init(self: Self) anyerror!*Context {
         .handlers = std.ArrayList(handlerFn).init(self.allocator),
         .index = self.index,
         .conn = self.conn,
+        .data = self.data,
     };
 
     return ctx;

--- a/src/zinc/engine.zig
+++ b/src/zinc/engine.zig
@@ -82,6 +82,7 @@ fn create(conf: Config.Engine) anyerror!*Engine {
         .router = try Router.init(.{
             .allocator = conf.allocator,
             .middlewares = std.ArrayList(HandlerFn).init(conf.allocator),
+            .data = conf.data,
         }),
         .middlewares = std.ArrayList(HandlerFn).init(conf.allocator),
         .threads = std.ArrayList(std.Thread).init(conf.allocator),

--- a/src/zinc/router.zig
+++ b/src/zinc/router.zig
@@ -39,6 +39,12 @@ route_tree: *RouteTree = undefined,
 
 catchers: ?*Catchers = undefined,
 
+data: *anyopaque,
+
+fn setData(self: Self, ptr: anytype) void {
+    self.data = ptr;
+}
+
 pub fn init(self: Self) anyerror!*Router {
     const r = try self.allocator.create(Router);
     errdefer self.allocator.destroy(r);
@@ -53,6 +59,7 @@ pub fn init(self: Self) anyerror!*Router {
             .routes = std.ArrayList(*Route).init(self.allocator),
         }),
         .catchers = try Catchers.init(self.allocator),
+        .data = self.data,
     };
     return r;
 }
@@ -84,7 +91,7 @@ pub fn handleConn(self: *Self, allocator: std.mem.Allocator, conn: std.net.Strea
     });
 
     const res = try Response.init(.{ .conn = conn, .allocator = allocator });
-    const ctx = try Context.init(.{ .request = req, .response = res, .allocator = allocator });
+    const ctx = try Context.init(.{ .request = req, .response = res, .allocator = allocator, .data = self.data });
     defer ctx.destroy();
 
     const match_route = self.getRoute(req_method, req_target) catch |err| {

--- a/src/zinc/routetree.zig
+++ b/src/zinc/routetree.zig
@@ -61,7 +61,7 @@ pub const RouteTree = struct {
         stack.append(self) catch unreachable;
 
         while (stack.items.len > 0) {
-            var node: *RouteTree = stack.pop();
+            var node: *RouteTree = stack.pop().?;
             defer node.destroy();
 
             if (node.children != null) {
@@ -377,7 +377,7 @@ pub const RouteTree = struct {
         childStack.append(self) catch unreachable;
 
         while (childStack.items.len > 0) {
-            const node: *RouteTree = childStack.pop();
+            const node: *RouteTree = childStack.pop().?;
 
             // append children routes to the routes
             if (node.routes != null) {


### PR DESCRIPTION
Set appdata that will be passed to each context. This is helpful when we want to access specific data inside our endpoint.

Example

```rust
var config = zinc.Config.Engine{ .port = 8080 };
config.appData(&store);
const engine = try zinc.init(config);

// and then in the endpoint
fn home(ctx: *zinc.Context) !void {
   const store: *Store = @ptrCast(@alignCast(ctx.data));
   _ = store;
    try ctx.text("Home page", .{});
}

```